### PR TITLE
fix: remove dangling cfg directive

### DIFF
--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -7,7 +7,6 @@ use crate::process_tracker::{ProcessTracker, find_child_process};
 use sysinfo::Pid;
 use std::fs;
 use serde_json::{self, json};
-#[cfg(unix)]
 
 /// State management for terminal sessions
 #[derive(Default)]


### PR DESCRIPTION
Removed a dangling cfg directive, causing `not found in scope` errors when compiling on Windows

fixes #6 